### PR TITLE
Create new queue when getting ERROR_QUEUE_NOT_FOUND

### DIFF
--- a/facebook/facebook-api.c
+++ b/facebook/facebook-api.c
@@ -274,6 +274,12 @@ static void fb_api_cb_mqtt_open(fb_mqtt_t *mqtt, gpointer data)
     g_free(msg);
 }
 
+/**
+ * Sends /messenger_sync_create_queue to create a new queue baed on the current
+ * sequence id (api->seqid)
+ *
+ * @param api The #fb_api.
+ **/
 static void fb_api_sync_create_queue(fb_api_t *api)
 {
     fb_api_publish(api, "/messenger_sync_create_queue", "{"

--- a/facebook/facebook-api.c
+++ b/facebook/facebook-api.c
@@ -22,6 +22,8 @@
 #include "facebook-api.h"
 #include "facebook-thrift.h"
 
+static void fb_api_sync_create_queue(fb_api_t *api);
+
 /**
  * Gets the error domain for #fb_api.
  *

--- a/facebook/facebook-api.c
+++ b/facebook/facebook-api.c
@@ -72,6 +72,11 @@ static gboolean fb_api_json_new(fb_api_t *api, const gchar *data, gsize size,
         json_value_free(jv);
         return FALSE;
     } else if (fb_json_str_chk(jv, "errorCode", &msg)) {
+        /* hack - make this non-fatal */
+        if (g_ascii_strcasecmp(msg, "ERROR_QUEUE_NOT_FOUND") == 0) {
+            *json = jv;
+            return TRUE;
+        }
         fb_api_error(api, FB_API_ERROR_GENERAL, "%s", msg);
         json_value_free(jv);
         return FALSE;
@@ -269,6 +274,19 @@ static void fb_api_cb_mqtt_open(fb_mqtt_t *mqtt, gpointer data)
     g_free(msg);
 }
 
+static void fb_api_sync_create_queue(fb_api_t *api)
+{
+    fb_api_publish(api, "/messenger_sync_create_queue", "{"
+            "\"device_params\":{},"
+            "\"encoding\":\"JSON\","
+            "\"max_deltas_able_to_process\":1250,"
+            "\"initial_titan_sequence_id\":%s,"
+            "\"sync_api_version\":2,"
+            "\"delta_batch_size\":125,"
+            "\"device_id\":\"%s\""
+        "}", api->seqid, api->cuid);
+}
+
 /**
  * Implemented #fb_http_func for the sequence identifier.
  *
@@ -308,17 +326,11 @@ static void fb_api_cb_seqid(fb_http_req_t *req, gpointer data)
         goto finish;
     }
 
-    if (G_UNLIKELY(api->stoken == NULL)) {
-        fb_api_publish(api, "/messenger_sync_create_queue", "{"
-                "\"device_params\":{},"
-                "\"encoding\":\"JSON\","
-                "\"max_deltas_able_to_process\":1250,"
-                "\"initial_titan_sequence_id\":%s,"
-                "\"sync_api_version\":2,"
-                "\"delta_batch_size\":125,"
-                "\"device_id\":\"%s\""
-            "}", str, api->cuid);
+    g_free(api->seqid);
+    api->seqid = g_strdup(str);
 
+    if (G_UNLIKELY(api->stoken == NULL)) {
+        fb_api_sync_create_queue(api);
         goto finish;
     }
 
@@ -452,6 +464,12 @@ static void fb_api_cb_publish_ms(fb_api_t *api, const GByteArray *pload)
         return;
 
     msgs = NULL;
+
+    if (fb_json_str_chk(json, "errorCode", &str) &&
+        g_ascii_strcasecmp(str, "ERROR_QUEUE_NOT_FOUND") == 0) {
+        fb_api_sync_create_queue(api);
+        goto finish;
+    }
 
     if (fb_json_str_chk(json, "syncToken", &str)) {
         g_free(api->stoken);
@@ -710,6 +728,7 @@ void fb_api_free(fb_api_t *api)
     fb_mqtt_free(api->mqtt);
     fb_http_free(api->http);
 
+    g_free(api->seqid);
     g_free(api->cuid);
     g_free(api->mid);
     g_free(api->cid);

--- a/facebook/facebook-api.h
+++ b/facebook/facebook-api.h
@@ -232,6 +232,7 @@ struct fb_api
     gchar   *cid;        /** The client identifier. **/
     gchar   *mid;        /** The MQTT identifier. **/
     gchar   *cuid;       /** The client unique identifier. **/
+    gchar   *seqid;      /** The sync sequence id **/
 };
 
 /**


### PR DESCRIPTION
Featuring not-very-elegant hack to avoid calling `fb_api_error()` in `fb_api_json_new()` for `ERROR_QUEUE_NOT_FOUND` only

Fixes #15 
