### PR TITLE
facebook-json: On parse error, show an escaped fragment of the input

### DIFF
--- a/facebook/facebook-json.c
+++ b/facebook/facebook-json.c
@@ -50,6 +50,8 @@ json_value *fb_json_new(const gchar *data, gsize length, GError **err)
     json_value    *json;
     json_settings  js;
     gchar         *estr;
+    gchar         *dstr;
+    gchar         *escaped;
 
     memset(&js, 0, sizeof js);
     estr = g_new0(gchar, json_error_max);
@@ -60,8 +62,15 @@ json_value *fb_json_new(const gchar *data, gsize length, GError **err)
         return json;
     }
 
+    /* Ensure it's null-terminated before passing it to g_strescape() */
+    dstr = g_strndup(data, MIN(length, 400));
+    escaped = g_strescape(dstr, "\"");
+
     g_set_error(err, FB_JSON_ERROR, FB_JSON_ERROR_PARSER,
-                "Parser: %s", estr);
+                "Parser: %s\nJSON len=%zd: %s", estr, length, escaped);
+
+    g_free(dstr);
+    g_free(escaped);
 
     g_free(estr);
     return NULL;


### PR DESCRIPTION
Just for debugging purposes with users who don't run this with debug enabled.

References #13 

Looks sorta like this (i made it fail in the first request to test it)

```
09:22 <@root> facebook - Login error: Parser: 1:0: Unexpected when seeking value
09:22 <@root> JSON len=209015: \123{"viewer":{"messenger_contacts":{"sync_id":"0","nodes":[{"id":"Y29udGFjdD
```

The length of the displayed fragment is capped to 400 chars and escaped with `g_strescape()`, which uses octal escapes for non-ascii values, which should be good enough to identify the problem.