### PR TITLE
Reset stoken when getting ERROR_QUEUE_NOT_FOUND, to create a new one

### DIFF
--- a/facebook/facebook-api.c
+++ b/facebook/facebook-api.c
@@ -72,6 +72,13 @@ static gboolean fb_api_json_new(fb_api_t *api, const gchar *data, gsize size,
         json_value_free(jv);
         return FALSE;
     } else if (fb_json_str_chk(jv, "errorCode", &msg)) {
+        if ((g_ascii_strcasecmp(msg, "ERROR_QUEUE_NOT_FOUND") == 0) ||
+            (g_ascii_strcasecmp(msg, "ERROR_QUEUE_LOST") == 0))
+        {
+            g_free(api->stoken);
+            api->stoken = NULL;
+        }
+
         fb_api_error(api, FB_API_ERROR_GENERAL, "%s", msg);
         json_value_free(jv);
         return FALSE;
@@ -308,7 +315,7 @@ static void fb_api_cb_seqid(fb_http_req_t *req, gpointer data)
         goto finish;
     }
 
-    if (G_UNLIKELY(api->stoken == NULL)) {
+    if (api->stoken == NULL) {
         fb_api_publish(api, "/messenger_sync_create_queue", "{"
                 "\"device_params\":{},"
                 "\"encoding\":\"JSON\","

--- a/facebook/facebook.c
+++ b/facebook/facebook.c
@@ -535,6 +535,10 @@ static void fb_logout(struct im_connection *ic)
 {
     fb_data_t *fata = ic->proto_data;
 
+    if (fata->api->stoken == NULL) {
+        set_reset(&ic->acc->set, "stoken");
+    }
+
     fb_api_disconnect(fata->api);
     fb_data_free(fata);
 }


### PR DESCRIPTION
Simpler and more verbose version of my other patch which silently
created a new queue - this will show up as a reconnection and should
make it obvious if an infinite loop happens. jgeboski's idea, not mine.

Replaces #16 