### PR TITLE
Lower GLib requirement to 2.28 (to cover RHEL/CentOS 6)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -77,7 +77,7 @@ AC_ARG_WITH(
 )
 
 PKG_CHECK_MODULES([BITLBEE], [bitlbee >= 3.4])
-PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.32.0 gobject-2.0])
+PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.28.0 gobject-2.0])
 PKG_CHECK_MODULES([JSON], [json-glib-1.0 >= 0.14.0])
 PKG_CHECK_MODULES([ZLIB], [zlib])
 

--- a/facebook/facebook-api.c
+++ b/facebook/facebook-api.c
@@ -26,6 +26,19 @@
 #include "facebook-thrift.h"
 #include "facebook-util.h"
 
+#if !GLIB_CHECK_VERSION(2, 32, 0)
+static inline GByteArray * g_byte_array_new_take(guint8 *data, gsize len)
+{
+	GByteArray *array;
+
+	array = g_byte_array_new();
+	g_byte_array_append(array, data, len);
+	g_free(data);
+
+	return array;
+}
+#endif
+
 typedef struct _FbApiData FbApiData;
 
 enum

--- a/facebook/facebook-data.c
+++ b/facebook/facebook-data.c
@@ -20,6 +20,18 @@
 #include "facebook-api.h"
 #include "facebook-data.h"
 
+#if !GLIB_CHECK_VERSION(2, 30, 0)
+#define G_VALUE_INIT {0, {{0}}}
+#endif
+
+#if !GLIB_CHECK_VERSION(2, 32, 0)
+static inline void g_queue_free_full(GQueue *queue, GDestroyNotify free_func)
+{
+	g_queue_foreach(queue, (GFunc)free_func, NULL);
+	g_queue_free(queue);
+}
+#endif
+
 struct _FbDataPrivate
 {
     FbApi *api;

--- a/facebook/facebook.c
+++ b/facebook/facebook.c
@@ -26,6 +26,10 @@
 #define OPT_SELFMESSAGE 0
 #endif
 
+#if !GLIB_CHECK_VERSION(2, 30, 0)
+#define G_VALUE_INIT {0, {{0}}}
+#endif
+
 static void
 fb_cb_api_messages(FbApi *api, GSList *msgs, gpointer data);
 


### PR DESCRIPTION
Lower GLib requirement to 2.28 (to cover RHEL/CentOS 6) as per #55, thanks to @dequis and @jgeboski